### PR TITLE
feat: make refetch awaitable

### DIFF
--- a/lib/src/hooks/use_query.dart
+++ b/lib/src/hooks/use_query.dart
@@ -15,7 +15,7 @@ class UseQueryResult<TData, TError> {
   final bool isFetching;
   final bool isSuccess;
   final QueryStatus status;
-  final void Function() refetch;
+  final Future<void> Function() refetch;
 
   UseQueryResult({
     required this.data,

--- a/lib/src/hooks/use_query.dart
+++ b/lib/src/hooks/use_query.dart
@@ -31,15 +31,12 @@ class UseQueryResult<TData, TError> {
   });
 }
 
-class UseQueryOptions<TData, TError> {
+class UseQueryOptions {
   final bool enabled;
   final RefetchOnMount? refetchOnMount;
   final Duration? staleDuration;
   final Duration? cacheDuration;
   final Duration? refetchInterval;
-
-  final ValueChanged<TData>? onData;
-  final ValueChanged<TError>? onError;
 
   UseQueryOptions({
     required this.enabled,
@@ -47,8 +44,6 @@ class UseQueryOptions<TData, TError> {
     this.staleDuration,
     this.cacheDuration,
     this.refetchInterval,
-    this.onData,
-    this.onError,
   });
 }
 
@@ -80,25 +75,21 @@ class UseQueryOptions<TData, TError> {
 
 UseQueryResult<TData, TError> useQuery<TData, TError>(
   QueryKey queryKey,
-  QueryFn<TData> fetcher, {
+  Future<TData> Function() fetcher, {
   // These options must match with the `UseQueryOptions`
   bool enabled = true,
   RefetchOnMount? refetchOnMount,
   Duration? staleDuration,
   Duration? cacheDuration,
   Duration? refetchInterval,
-  final ValueChanged<TData>? onData,
-  final ValueChanged<TError>? onError,
 }) {
   final options = useMemoized(
-    () => UseQueryOptions<TData, TError>(
+    () => UseQueryOptions(
       enabled: enabled,
       refetchOnMount: refetchOnMount,
       staleDuration: staleDuration,
       cacheDuration: cacheDuration,
       refetchInterval: refetchInterval,
-      onData: onData,
-      onError: onError,
     ),
     [
       enabled,
@@ -106,12 +97,10 @@ UseQueryResult<TData, TError> useQuery<TData, TError>(
       staleDuration,
       cacheDuration,
       refetchInterval,
-      onData,
-      onError,
     ],
   );
   final client = useQueryClient();
-  final observer = useMemoized<Observer<TData, TError>>(
+  final observer = useMemoized(
     () => Observer<TData, TError>(
       queryKey,
       fetcher,
@@ -123,7 +112,7 @@ UseQueryResult<TData, TError> useQuery<TData, TError>(
 
   // This subscribes to the observer
   // and rebuilds the widgets on updates.
-  useListenable<Observer<TData, TError>>(observer);
+  useListenable(observer);
 
   useEffect(() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -141,7 +130,7 @@ UseQueryResult<TData, TError> useQuery<TData, TError>(
     };
   }, [observer]);
 
-  return UseQueryResult<TData, TError>(
+  return UseQueryResult(
     data: observer.query.state.data,
     dataUpdatedAt: observer.query.state.dataUpdatedAt,
     error: observer.query.state.error,

--- a/lib/src/observer.dart
+++ b/lib/src/observer.dart
@@ -110,15 +110,14 @@ class Observer<TData, TError> extends ChangeNotifier {
   }
 
   /// This is "the" function responsible for fetching the query.
-  void fetch() async {
+  Future<void> fetch() async {
     if (!options.enabled || query.state.isFetching) {
       return;
     }
 
     query.dispatch(DispatchAction.fetch, null);
-    // Important: State change, then any other
-    // function invocation in the following callbacks
-    resolver.resolve<TData>(fetcher, onResolve: (data) {
+    await resolver.resolve<TData>(fetcher, onResolve: (data) {
+      options.onData?.call(data);
       query.dispatch(DispatchAction.success, data);
 
       options.onData?.call(data);

--- a/lib/src/observer.dart
+++ b/lib/src/observer.dart
@@ -116,8 +116,9 @@ class Observer<TData, TError> extends ChangeNotifier {
     }
 
     query.dispatch(DispatchAction.fetch, null);
+    // Important: State change, then any other
+    // function invocation in the following callbacks
     await resolver.resolve<TData>(fetcher, onResolve: (data) {
-      options.onData?.call(data);
       query.dispatch(DispatchAction.success, data);
 
       options.onData?.call(data);


### PR DESCRIPTION
This is very helpful when use it with [pull to refresh](https://pub.dev/packages/pull_to_refresh)
```dart
final refreshController =
        useMemoized(() => RefreshController(initialRefresh: false));

final posts = useQuery(['posts'], getPosts);

void onRefresh() async {
      await posts.refetch();
      refreshController.refreshCompleted();
}

SmartRefresher(
      controller: refreshController,
      onRefresh: onRefresh,
      //...
)
```