### PR TITLE
fix: run fetching when enabled option changed to true

### DIFF
--- a/lib/src/observer.dart
+++ b/lib/src/observer.dart
@@ -85,22 +85,22 @@ class Observer<TData, TError> extends ChangeNotifier {
   void updateOptions(UseQueryOptions options) {
     final refetchIntervalChanged =
         this.options.refetchInterval != options.refetchInterval;
-    final enabledChanged = this.options.enabled != options.enabled;
+    final isEnabledChanged = this.options.enabled != options.enabled;
 
     _setOptions(options);
 
-    if (enabledChanged) {
-      if (options.enabled == true) {
+    if (isEnabledChanged) {
+      if (options.enabled) {
         fetch();
       } else {
         resolver.cancel();
+        refetchTimer?.cancel();
       }
     }
 
     if (options.cacheDuration != null) {
       query.setCacheDuration(options.cacheDuration as Duration);
     }
-
     if (refetchIntervalChanged) {
       // Schedules the next fetch if the [options.refetchInterval] is set.
       if (options.refetchInterval != null) {

--- a/lib/src/observer.dart
+++ b/lib/src/observer.dart
@@ -85,8 +85,17 @@ class Observer<TData, TError> extends ChangeNotifier {
   void updateOptions(UseQueryOptions options) {
     final refetchIntervalChanged =
         this.options.refetchInterval != options.refetchInterval;
+    final enabledChanged = this.options.enabled != options.enabled;
 
     _setOptions(options);
+
+    if (enabledChanged) {
+      if (options.enabled == true) {
+        fetch();
+      } else {
+        resolver.cancel();
+      }
+    }
 
     if (options.cacheDuration != null) {
       query.setCacheDuration(options.cacheDuration as Duration);


### PR DESCRIPTION
Closes #8 

```dart
final isEnabled = useState(false);

final post = useQuery(
      ['posts'],
      getPosts,
      // After setting the enabled option to `true`, it will run fetching automatically
      enabled: isEnabled.value,
)

 useEffect(() {
      // after 5 seconds, isEnabled will be set to true
      Future.delayed(const Duration(seconds: 5), () {
        isEnabled.value = true;
      });
      return () {};
    }, []);
```