### PR TITLE
fix: Fix a bug where the retryCount & retryDelay parameters do not change

### DIFF
--- a/lib/src/observer.dart
+++ b/lib/src/observer.dart
@@ -130,15 +130,22 @@ class Observer<TData, TError> extends ChangeNotifier with QueryListener {
     query.dispatch(DispatchAction.fetch, null);
     // Important: State change, then any other
     // function invocation in the following callbacks
-    await resolver.resolve<TData>(fetcher, onResolve: (data) {
-      query.dispatch(DispatchAction.success, data);
-    }, onError: (error) {
-      final action =
-          isRefetching ? DispatchAction.refetchError : DispatchAction.error;
-      query.dispatch(action, error);
-    }, onCancel: () {
-      query.dispatch(DispatchAction.cancelFetch, null);
-    });
+    await resolver.resolve<TData>(
+      fetcher,
+      retryCount: options.retryCount,
+      retryDelay: options.retryDelay,
+      onResolve: (data) {
+        query.dispatch(DispatchAction.success, data);
+      },
+      onError: (error) {
+        final action =
+            isRefetching ? DispatchAction.refetchError : DispatchAction.error;
+        query.dispatch(action, error);
+      },
+      onCancel: () {
+        query.dispatch(DispatchAction.cancelFetch, null);
+      },
+    );
   }
 
   /// This is called from the [Query] class whenever the query state changes.

--- a/lib/src/queries_observer.dart
+++ b/lib/src/queries_observer.dart
@@ -48,6 +48,8 @@ class QueriesObserver<TData, TError> extends ChangeNotifier {
                 refetchInterval: option.refetchInterval,
                 refetchOnMount: option.refetchOnMount,
                 staleDuration: option.staleDuration,
+                retryCount: option.retryCount,
+                retryDelay: option.retryDelay,
               ),
             );
 
@@ -58,6 +60,8 @@ class QueriesObserver<TData, TError> extends ChangeNotifier {
             refetchInterval: option.refetchInterval,
             refetchOnMount: option.refetchOnMount,
             staleDuration: option.staleDuration,
+            retryCount: option.retryCount,
+            retryDelay: option.retryDelay,
           ));
         });
         return observer;


### PR DESCRIPTION
Thank you for creating a awesome library :dog:

We have fixed a bug where `retryCount` and `retryDelay` could not be changed. Although these can be specified in APIs such as `useQuery`, the issue was that they were not being passed to `RetryObserver`.

```dart
// Repro:
useQuery(
  ['posts'],
  getPosts,
  retryCount: 1, //  <-- The number of retries specified by `retryCount` is ignored :)
  retryDelay: const Duration(seconds: 3),
);
```