### PR TITLE
refactor: Enable default values for `retryCount` and `retryDelay`

### DIFF
--- a/lib/src/hooks/use_infinite_query.dart
+++ b/lib/src/hooks/use_infinite_query.dart
@@ -144,8 +144,8 @@ UseInfiniteQueryResult<TData, TError, TPageParam>
   Duration? staleDuration,
   Duration? cacheDuration,
   Duration? refetchInterval,
-  int retryCount = 3,
-  Duration retryDelay = const Duration(seconds: 1, milliseconds: 500),
+  int? retryCount,
+  Duration? retryDelay,
 }) {
   final options = useMemoized(
     () => UseInfiniteQueryOptions<TData, TError, TPageParam>(

--- a/lib/src/hooks/use_query.dart
+++ b/lib/src/hooks/use_query.dart
@@ -41,8 +41,8 @@ class UseQueryOptions<TData, TError> {
   final Duration? staleDuration;
   final Duration? cacheDuration;
   final Duration? refetchInterval;
-  final int retryCount;
-  final Duration retryDelay;
+  final int? retryCount;
+  final Duration? retryDelay;
 
   UseQueryOptions({
     required this.enabled,
@@ -50,8 +50,8 @@ class UseQueryOptions<TData, TError> {
     this.staleDuration,
     this.cacheDuration,
     this.refetchInterval,
-    this.retryCount = 3,
-    this.retryDelay = const Duration(seconds: 1, milliseconds: 500),
+    this.retryCount,
+    this.retryDelay,
   });
 }
 
@@ -90,8 +90,8 @@ UseQueryResult<TData, TError> useQuery<TData, TError>(
   Duration? staleDuration,
   Duration? cacheDuration,
   Duration? refetchInterval,
-  int retryCount = 3,
-  Duration retryDelay = const Duration(seconds: 1, milliseconds: 500),
+  int? retryCount,
+  Duration? retryDelay,
 }) {
   final options = useMemoized(
     () => UseQueryOptions<TData, TError>(

--- a/lib/src/observer.dart
+++ b/lib/src/observer.dart
@@ -80,8 +80,8 @@ class Observer<TData, TError> extends ChangeNotifier with QueryListener {
       cacheDuration:
           options.cacheDuration ?? client.defaultQueryOptions.cacheDuration,
       refetchInterval: options.refetchInterval,
-      retryCount: options.retryCount,
-      retryDelay: options.retryDelay,
+      retryCount: options.retryCount ?? client.defaultQueryOptions.retryCount,
+      retryDelay: options.retryDelay ?? client.defaultQueryOptions.retryDelay,
     );
   }
 

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -44,8 +44,8 @@ class QueryOptions<TData, TError> {
     required this.staleDuration,
     required this.cacheDuration,
     this.refetchInterval,
-    this.retryCount = 3,
-    this.retryDelay = const Duration(seconds: 1, milliseconds: 500),
+    required this.retryCount,
+    required this.retryDelay,
   });
 }
 

--- a/lib/src/retry_resolver.dart
+++ b/lib/src/retry_resolver.dart
@@ -8,8 +8,8 @@ class RetryResolver {
 
   Future<void> resolve<T>(
     FutureOr<T> Function() fn, {
-    int retryCount = 3,
-    Duration retryDelay = const Duration(seconds: 1, milliseconds: 500),
+    required int retryCount,
+    required Duration retryDelay,
     required void Function(T value) onResolve,
     required void Function(dynamic error) onError,
     required void Function() onCancel,

--- a/lib/src/widgets/query_builder.dart
+++ b/lib/src/widgets/query_builder.dart
@@ -14,8 +14,8 @@ class QueryBuilder<TData, TError> extends HookWidget {
   final Duration? staleDuration;
   final Duration? cacheDuration;
   final Duration? refetchInterval;
-  final int retryCount;
-  final Duration retryDelay;
+  final int? retryCount;
+  final Duration? retryDelay;
 
   const QueryBuilder(
     this.queryKey,
@@ -27,8 +27,8 @@ class QueryBuilder<TData, TError> extends HookWidget {
     this.staleDuration,
     this.cacheDuration,
     this.refetchInterval,
-    this.retryCount = 3,
-    this.retryDelay = const Duration(seconds: 1, milliseconds: 500),
+    this.retryCount,
+    this.retryDelay,
   });
 
   @override


### PR DESCRIPTION
## Summary

I have refactored the code so that `retryCount` and `retryDelay` specified in `DefaultQueryOptions` are used in each API :dog:

```dart
final queryClient = QueryClient(
  defaultQueryOptions: DefaultQueryOptions(
    retryCount: 2,                          //  <--  The values specified on this line will be treated as the default values.
    retryDelay: const Duration(seconds: 2), //  <--  Same above.
  ),
);
```

## References

- Resolves #29