### PR TITLE
remove redundant loop in invalidateQueries

### DIFF
--- a/packages/fquery_core/lib/src/query_cache.dart
+++ b/packages/fquery_core/lib/src/query_cache.dart
@@ -281,7 +281,6 @@ class QueryCache with Observable {
     // No concurrent modification error is probable
     // because we are not removing from the map
     // but just consistency with `removeQueries`
-    queries.forEach((queryKey, query) {
       final toInvalidate = <Query<TData, TError>>[];
 
       queries.forEach((queryKey, query) {
@@ -303,7 +302,6 @@ class QueryCache with Observable {
       for (final query in toInvalidate) {
         dispatch(query.key, DispatchAction.invalidate, null);
       }
-    });
   }
 
   /// Removes queries from the cache.


### PR DESCRIPTION
In method invalidateQueries of package fquery_core there is a redundant loop. By removing it there will be less loops and increases performance
It's also described here: https://github.com/41y08h/fquery/issues/51