### PR TITLE
fix: remove unnecessary nested forEach loop in invalidateQueries

### DIFF
--- a/packages/fquery_core/lib/src/query_cache.dart
+++ b/packages/fquery_core/lib/src/query_cache.dart
@@ -281,29 +281,27 @@ class QueryCache with Observable {
     // No concurrent modification error is probable
     // because we are not removing from the map
     // but just consistency with `removeQueries`
+    final toInvalidate = <Query<TData, TError>>[];
+
     queries.forEach((queryKey, query) {
-      final toInvalidate = <Query<TData, TError>>[];
-
-      queries.forEach((queryKey, query) {
-        if (exact) {
-          if (queryKey.serialized == QueryKey(key).serialized &&
-              query is Query<TData, TError>) {
-            toInvalidate.add(query);
-          }
-        } else {
-          final isPartialMatch = queryKey.raw.length >= key.length &&
-              QueryKey(queryKey.raw.sublist(0, key.length)) == QueryKey(key);
-
-          if (isPartialMatch && query is Query<TData, TError>) {
-            toInvalidate.add(query);
-          }
+      if (exact) {
+        if (queryKey.serialized == QueryKey(key).serialized &&
+            query is Query<TData, TError>) {
+          toInvalidate.add(query);
         }
-      });
+      } else {
+        final isPartialMatch = queryKey.raw.length >= key.length &&
+            QueryKey(queryKey.raw.sublist(0, key.length)) == QueryKey(key);
 
-      for (final query in toInvalidate) {
-        dispatch(query.key, DispatchAction.invalidate, null);
+        if (isPartialMatch && query is Query<TData, TError>) {
+          toInvalidate.add(query);
+        }
       }
     });
+
+    for (final query in toInvalidate) {
+      dispatch(query.key, DispatchAction.invalidate, null);
+    }
   }
 
   /// Removes queries from the cache.


### PR DESCRIPTION
## Summary

  Remove unnecessary nested `forEach` loop in `QueryCache.invalidateQueries` method that caused O(N²) time complexity and duplicate invalidation calls.

  ## Problem

  The `invalidateQueries` method had a redundant outer `forEach` loop:

  - The outer loop served no purpose - all query checking was done in the inner loop
  - Variable shadowing occurred with `queryKey` and `query` being declared in both loops
  - Time complexity was O(N²) instead of O(N)
  - The same query could be invalidated multiple times per outer loop iteration

  ## Solution

  Removed the unnecessary outer `forEach` loop, making the implementation consistent with the existing `removeQueries` method pattern.

  ## Changes

  - `packages/fquery_core/lib/src/query_cache.dart`: Simplified `invalidateQueries` by removing redundant nested loop
